### PR TITLE
add gitignore file that includes .DS_Store, a common mac file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Mac computers commonly add a file .DS_Store to folders that does not need to be pushed to the team remote repository.  The .gitignore file is a list of files and folders that are found in our local repositories that will not be pushed to the remote repository, a list of files and folders that 'git will ignore'.