### PR TITLE
remove autofocus from Tab 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
     <nav class="nav-bar">
         <div class="decorative-line"></div>
         <div class="tabs">
-            <button autofocus class="tab" type="button">Tab 1</button>
+            <button class="tab" type="button">Tab 1</button>
             <button class="tab" type="button">Tab 2</button>
             <button class="tab" type="button">Tab 3</button>
         </div>


### PR DESCRIPTION
I had added an autofocus to Tab1 to make it black, but it also made the newly opened webpage open to that section instead of the top of the page.  This pull request removes the autofocus keyword.

A combination of css and javascript can be used to make the first tab black and to keep the current tag black, like I used on the continent buttons in map-tools.js