### PR TITLE
Fix integrate diet tool

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,12 +151,12 @@ function countDinosaursPerCountry(dinosaurs) {
 /*** Dinosaurs Diets ***/
 const tableData = createTableData(dinosaurs)
 console.log('tableData = ', tableData)
-createChart(tableData)
+createChart()
 
-function createChart(data) {
-  const graph = document.getElementById('graph');
+function createChart() {
+  const ctx = document.getElementById('myChart');
 
-  new Chart(graph, {
+  new Chart(ctx, {
     type: 'doughnut',
     data: {
       labels: ['Red', 'Blue', 'Yellow'],

--- a/diet.css
+++ b/diet.css
@@ -35,14 +35,17 @@ h1 {
     padding: 3px 20px;
     flex: 2;
 }
-.chart-container {
-    width: 200px;
-    height: 300px;
+.image-container {
     display: flex;
     align-items: center;
     justify-content: center;
 }
-#graph {
+img {
     padding: 20px;
 }
+.chart-container {
+    max-width: 40rem;
+    padding: auto;
+    margin: 25vh auto;
+  }
 

--- a/index.html
+++ b/index.html
@@ -226,7 +226,6 @@
                 <header>
                     <h1>Learn about dinosaur diets!</h1>
                 </header>
-            
                 <div class="lower-container">
                     <div class="text-container">
                         <p>Now that you’ve learned a bit about dinosaurs, it’s important to understand more about their diets</p>
@@ -234,12 +233,16 @@
                         <p>Tap each period to see the breakdown of dinosaur diets during that period in the pie chart below.</p>
                         <p>Then, hover over each section of the pie chart to see what this diet could have looked like!</p>
                     </div>
-                    <div class="chart-container">
-                        <canvas id="graph"></canvas>
+                    <div class="image-container">
+                        <img src="https://dummyimage.com/200x300/000/fff">
                     </div>
                 </div> <!-- end lower-container -->
             </div> <!-- end outer-container -->
             </div> <!-- end diet.html-body -->
+            
+            <div class="chart-container">
+                <canvas id="myChart"></canvas>
+            </div>
     </section>
 
     <!-- Footer -->


### PR DESCRIPTION
In my previous pull request #127 "Integrate Diets code into index.html and app.js", I moved the chart into the incorrect position.  This pull request fixes my mistake.

This is the wireframe:
![Screen Shot 2024-04-01 at 1 38 47 PM](https://github.com/chingu-voyages/v48-tier1-team-05/assets/51532684/9dfe0f20-5eca-4bc9-8cc8-f43342d800ba)

This is the previous diet.html and diet.css
![Screen Shot 2024-04-01 at 1 30 17 PM](https://github.com/chingu-voyages/v48-tier1-team-05/assets/51532684/504bdd1b-f4cb-4e69-bf7c-1c4b3589b6cd)

I mistakenly put the chart where the time period table should go.
![Screen Shot 2024-04-01 at 1 32 23 PM](https://github.com/chingu-voyages/v48-tier1-team-05/assets/51532684/4bb32fd1-18b8-43d6-a8fb-2ff698deef0f)

This pull request reverts back to the correct html and css, but now the html is found in index.html instead of diet.html.  Now the chart shows below the tool explanation and time period table container.
![Screen Shot 2024-04-01 at 1 30 42 PM](https://github.com/chingu-voyages/v48-tier1-team-05/assets/51532684/ab8b29b4-ce9d-4863-af56-cc633cb454a9)

