### PR TITLE
add hardcoded mesozoic chart data

### DIFF
--- a/app.js
+++ b/app.js
@@ -159,10 +159,9 @@ function createChart(data) {
   new Chart(graph, {
     type: 'doughnut',
     data: {
-      labels: ['Red', 'Blue', 'Yellow'],
+      labels: ['Herbivorous', 'Carnivorous', 'Omnivourous'],
       datasets: [{
-        label: '# of Votes',
-        data: [12, 19, 3],
+        data: [41, 28, 6],
         borderWidth: 1,
         hoverOffset: 4
       }]

--- a/app.js
+++ b/app.js
@@ -159,7 +159,7 @@ function createChart(data) {
   new Chart(graph, {
     type: 'doughnut',
     data: {
-      labels: ['Herbivorous', 'Carnivorous', 'Omnivourous'],
+      labels: ['Herbivorous', 'Carnivorous', 'Omnivorous'],
       datasets: [{
         data: [41, 28, 6],
         borderWidth: 1,


### PR DESCRIPTION
Using the dinosaur.json data, the count of dinosaurs per type of diet for the entire Mesozoic Era is as follows:

mesozoic: {herbivorous: 41, carnivorous: 28, omnivorous: 6}

I hardcoded that data into Daeha's chart.
```js
new Chart(graph, {
    type: 'doughnut',
    data: {
      labels: ['Herbivorous', 'Carnivorous', 'Omnivorous'],
      datasets: [{
        data: [41, 28, 6],
        borderWidth: 1,
        hoverOffset: 4
      }]
    },
```