### PR TITLE
Implement card flip - without length solution

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,13 +76,27 @@ function onSearch(data) {
     resultContainer.innerHTML = '';
 
     filtered.forEach((dinosaur) => {
-  
-      const cardContainer = document.createElement('div');
-      cardContainer.classList.add('card-container');
-      cardContainer.style.width = "100%";
-      cardContainer.style.marginBottom = "30px";
-      const dlElement = document.createElement('dl');
-  
+      // create elements needed
+      const card = document.createElement('div');
+      const cardBody = document.createElement('div');
+      const cardFront = document.createElement('div');
+      const cardFrontText = document.createElement('p');
+      const cardBack = document.createElement('div');
+      const cardBackText = document.createElement('div');
+      const cardBackImageContainer = document.createElement('div');
+      card.classList.add('card');
+      cardBody.classList.add('card-body')
+      cardFront.classList.add('card-front');
+      cardBack.classList.add('card-back');
+      cardBackText.classList.add('card-back-text');
+      cardBackImageContainer.classList.add('card-back-image-container');
+
+      // create card front
+      cardFrontText.textContent = dinosaur.name;
+      cardFront.appendChild(cardFrontText);
+
+      // create card back
+      // create card back text
       const labels = [
         { label: 'Type Species', data: dinosaur.typeSpecies },
         { label: 'Length', data: dinosaur.length },
@@ -91,32 +105,36 @@ function onSearch(data) {
         { label: 'Species', data: dinosaur.typeSpecies },
         { label: 'Description', data: dinosaur.description }
       ];
-  
       labels.forEach(item => {
+        const dlElement = document.createElement('dl');
         const dtElement = document.createElement('dt');
-        const spanElement = document.createElement('span');
         const ddElement = document.createElement('dd');
+        const spanElement = document.createElement('span');
         spanElement.textContent = item.label + ':';
         ddElement.textContent = item.data;
         dtElement.appendChild(spanElement);
         dlElement.appendChild(dtElement);
         dlElement.appendChild(ddElement);
+        cardBackText.appendChild(dlElement);
       });
+      
   
-      // Append dl to card container
-      cardContainer.appendChild(dlElement);
-  
-      // Create img element for each dinosaur
+      // create card back image
       const imgElement = document.createElement('img');
       imgElement.src = dinosaur.imageSrc;
-      imgElement.width = 330;
-      imgElement.height = 250;
+      imgElement.width = 200;
+      imgElement.height = 200;
+      cardBackImageContainer.appendChild(imgElement);
 
-    // Append img element to card container
-    cardContainer.appendChild(imgElement);
+      // create card from components
+      cardBack.appendChild(cardBackText);
+      cardBack.appendChild(cardBackImageContainer)
+      cardBody.appendChild(cardFront)
+      cardBody.appendChild(cardBack)
+      card.appendChild(cardBody)
 
-    // Append card container to result container
-    resultContainer.appendChild(cardContainer);
+      // append to result container
+      resultContainer.appendChild(card);
   });
 
 };

--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ function onSearch(data) {
     const filtered = data.filter((dinosaur) => {
         if (!search) {
             dinosaur.doesMatch = true;
-            return false;
+            return true;
         } else {
             const name = dinosaur.name.toLowerCase();
             const nameMatch = name.includes(search);

--- a/app.js
+++ b/app.js
@@ -53,7 +53,6 @@ function handleClick(event) {
 
 
 /********************************* Dinosaur Profiles *********************************/
-const dinoContainer = document.getElementById('all-dinos-container');
 
 function onSearch(data) {
     const search = document.getElementById("dinoSearch").value.toLowerCase();

--- a/app.js
+++ b/app.js
@@ -25,6 +25,9 @@ async function createData() {
     // create diet data for Diet Tool
     dietData = createDietData(allDinosaurs)
     console.log("diet data", dietData)
+
+    // show all dinosaurs by calling onSearch function
+    onSearch(allDinosaurs)
     return data
 
   } catch(err) {

--- a/index.html
+++ b/index.html
@@ -90,13 +90,7 @@
             />
             <button type="button"><img src="./assets/search_google_icon.png" alt=""></button>
         </form>
-        <div class="card-container">
-            <div class="card-container-1" id="search-result">
-        
-            </div>
-
-            <div class="card-container-2"></div>
-        </div> <!-- end card-container -->
+        <div id="search-result" class="dinosaur-cards"></div>
         <div class="results-end">
             <p>End of results!</p>
             <hr />

--- a/styles.css
+++ b/styles.css
@@ -358,9 +358,7 @@ span {
     border: 1px solid white;
     perspective: 1000px; /* Remove this if you don't want the 3D effect */
 }
-
-/* This container is needed to position the front and back side */
-.card-inner {
+.card-body {
   position: relative;
   width: 100%;
   height: 100%;
@@ -369,9 +367,7 @@ span {
   transform-style: preserve-3d;
   margin-bottom: 100px;
 }
-
-/* Do an horizontal flip when you move the mouse over the flip box container */
-.card:hover .card-inner {
+.card:hover .card-body {
   transform: rotateY(180deg);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -384,6 +384,17 @@ span {
   color: white;
   border-radius: .5em;
 }
+.green-gradient {
+  background: linear-gradient(#2F683B,#09150C);
+}
+.blue-gradient {
+  background: linear-gradient(#315394,#0A0F22);
+}
+.red-gradient {
+  background: linear-gradient(#722E2E,#150909);
+}
+.orange-gradient {
+  background: linear-gradient(#9A472C,#261009);
 }
 .card-back {
   background-color: dodgerblue;

--- a/styles.css
+++ b/styles.css
@@ -355,8 +355,7 @@ span {
     background-color: transparent;
     width: 1000px;
     height: 500px;
-    border: 1px solid white;
-    perspective: 1000px; /* Remove this if you don't want the 3D effect */
+    perspective: 1000px;
 }
 .card-body {
   position: relative;

--- a/styles.css
+++ b/styles.css
@@ -266,6 +266,9 @@ font-weight: 400;
   justify-content: center;
   border-radius: 0 1em 1em 0;
 }
+.card-back-image-container img {
+  object-fit: contain;
+}
 dl {
   display: grid;
   grid-template-columns: max-content 200px;

--- a/styles.css
+++ b/styles.css
@@ -349,7 +349,7 @@ span {
   color: white;
 } */
 
-/* The flip card container - set the width and height to whatever you want. We have added the border property to demonstrate that the flip itself goes out of the box on hover (remove perspective if you don't want the 3D effect */
+
 .card {
     margin-bottom: 50px;
     background-color: transparent;
@@ -369,8 +369,6 @@ span {
 .card:hover .card-body {
   transform: rotateY(180deg);
 }
-
-/* Position the front and back side */
 .card-front, .card-back {
   position: absolute;
   width: 100%;
@@ -378,14 +376,10 @@ span {
   -webkit-backface-visibility: hidden; /* Safari */
   backface-visibility: hidden;
 }
-
-/* Style the front side (fallback if image is missing) */
 .card-front {
   background-color: lightblue;
   color: black;
 }
-
-/* Style the back side */
 .card-back {
   background-color: dodgerblue;
   color: white;

--- a/styles.css
+++ b/styles.css
@@ -245,8 +245,19 @@ font-weight: 400;
   display: inline-flex;
   font: 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
   background-color: white;
-  border: 1pt solid green;
   transform: rotateY(180deg);
+}
+.card:nth-child(4n+1) .card-back {
+  border: 2pt solid #2F683B;
+}
+.card:nth-child(4n+2) .card-back {
+  border: 2pt solid #315394;
+}
+.card:nth-child(4n+3) .card-back {
+  border: 2pt solid #722E2E;
+}
+.card:nth-child(4n+4) .card-back {
+  border: 2pt solid #9A472C;
 }
 .card-back-text {
   width: 300px;

--- a/styles.css
+++ b/styles.css
@@ -351,11 +351,11 @@ span {
 
 
 .card {
-    margin-bottom: 50px;
-    background-color: transparent;
-    width: 1000px;
-    height: 500px;
-    perspective: 1000px;
+  width: 550px;
+  min-height: 300px;
+  background-color: transparent;
+  border-radius: .5rem;
+  perspective: 1000px;
 }
 .card-body {
   position: relative;

--- a/styles.css
+++ b/styles.css
@@ -228,53 +228,30 @@ font-weight: 400;
   font: 2.5em "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: white;
 }
-.card:nth-child(4n+1) .card-front {
-  background: linear-gradient(#2F683B,#09150C);
-}
-.card:nth-child(4n+2) .card-front {
-  background: linear-gradient(#315394,#0A0F22);
-}
-.card:nth-child(4n+3) .card-front {
-  background: linear-gradient(#722E2E,#150909);
-}
-.card:nth-child(4n+4) .card-front {
-  background: linear-gradient(#9A472C,#261009);
-}
 .card-back {
   padding: 10px;
-  display: inline-flex;
+  display: flex;
   font: 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
-  background-color: white;
   transform: rotateY(180deg);
 }
-.card:nth-child(4n+1) .card-back {
-  border: 2pt solid #2F683B;
-}
-.card:nth-child(4n+2) .card-back {
-  border: 2pt solid #315394;
-}
-.card:nth-child(4n+3) .card-back {
-  border: 2pt solid #722E2E;
-}
-.card:nth-child(4n+4) .card-back {
-  border: 2pt solid #9A472C;
-}
 .card-back-text {
-  width: 300px;
+  width: 310px;
   min-height: 300px;
   padding-top: 10px;
   padding-bottom: 10px;
   padding-left: 10px;
   padding-right: 10px;
+  background-color: white;
   border-radius: 1em 0 0 1em;
 }
 .card-back-image-container {
   width: 220px;
-  min-height: 300px;
+  height: 300px;
   padding: 10px;
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: white;
   border-radius: 0 1em 1em 0;
 }
 .card-back-image-container img {
@@ -301,16 +278,20 @@ span2 {
   padding-top: 4px;
   padding-bottom: 4px;
 }
-.green-gradient {
+.card:nth-child(4n+1) .card-front,
+.card:nth-child(4n+1) .card-back {
   background: linear-gradient(#2F683B,#09150C);
 }
-.blue-gradient {
+.card:nth-child(4n+2) .card-front,
+.card:nth-child(4n+2) .card-back {
   background: linear-gradient(#315394,#0A0F22);
 }
-.red-gradient {
+.card:nth-child(4n+3) .card-front,
+.card:nth-child(4n+3) .card-back {
   background: linear-gradient(#722E2E,#150909);
 }
-.orange-gradient {
+.card:nth-child(4n+4) .card-front,
+.card:nth-child(4n+4) .card-back {
   background: linear-gradient(#9A472C,#261009);
 }
 /********************************* Mobile Dinosaur Cards *********************************/

--- a/styles.css
+++ b/styles.css
@@ -192,65 +192,112 @@ font-weight: 400;
   border: none;
 }
 
-
-dl {
-  display: grid;
-  grid-template-columns: max-content 200px;
+/********************************* Desktop Dinosaur Cards *********************************/
+.card {
+  width: 550px;
+  min-height: 300px;
+  background-color: transparent;
+  border-radius: 1rem;
+  perspective: 1000px;
 }
-
-dt {
-  padding-bottom: 20px;
-  margin-right: -30px;
-
+.card-body {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.8s;
+  transform-style: preserve-3d;
+  margin-bottom: 100px;
 }
-
-
-span {
-  background-color: #777;
-  border-radius: 4px;
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-top: 2px;
-  padding-bottom: 2px;
+.card:hover .card-body {
+  transform: rotateY(180deg);
 }
-
-* {box-sizing: border-box;}
-
-
-.card-container {  
-  border: 5px solid #777;
-  border-radius: .5em;
-  padding: 15px;
+.card-front, .card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  -webkit-backface-visibility: hidden; /* Safari */
+  backface-visibility: hidden;
+}
+.card-front {
   display: flex;
+  justify-content: center;
   align-items: center;
-  font: 1em Helvetica Neue, Helvetica, Arial, sans-serif;
-  width: 70%;
-  margin-right: 1em;
+  font: 2.5em "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: white;
+  border-radius: 1em;
 }
-
-.card-container-1 {
+.card-back {
+  border-radius: 1em;
+  padding: 10px;
+  display: inline-flex;
+  font: 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.card-back-text {
+  width: 300px;
   min-height: 300px;
   padding-top: 10px;
   padding-bottom: 10px;
   padding-left: 10px;
   padding-right: 10px;
   background-color: #fff;
-  border: 2px solid #fff;
-
+  border: 0px solid #fff;
+  border-radius: .5em 0 0 .5em;
 }
-
-.card-container-2 {
-  width: 300px;
+.card-back-image-container {
+  width: 220px;
   min-height: 300px;
   padding: 10px;
   background-color: #fff;
-  border: 2px solid #fff;
+  border: 0px solid #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-
+  border-radius: 0 .5em .5em 0;
 }
-
+dl {
+  display: grid;
+  grid-template-columns: max-content 200px;
+}
+dt {
+  grid-column-start: 1;
+  padding-bottom: 20px;
+  margin-right: -30px;
+}
+dd {
+  grid-column-start: 2;
+}
+span2 {
+  background-color: #000;
+  color: #fff;
+  border-radius: 4px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+.green-gradient {
+  background: linear-gradient(#2F683B,#09150C);
+}
+.blue-gradient {
+  background: linear-gradient(#315394,#0A0F22);
+}
+.red-gradient {
+  background: linear-gradient(#722E2E,#150909);
+}
+.orange-gradient {
+  background: linear-gradient(#9A472C,#261009);
+}
+/********************************* Mobile Dinosaur Cards *********************************/
+span {
+  background-color: #000;
+  color: #fff;
+  border-radius: 4px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
 
 
 .results-end {
@@ -348,56 +395,3 @@ span {
   display: inline-block;
   color: white;
 } */
-
-
-.card {
-  width: 550px;
-  min-height: 300px;
-  background-color: transparent;
-  border-radius: .5rem;
-  perspective: 1000px;
-}
-.card-body {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  text-align: center;
-  transition: transform 0.8s;
-  transform-style: preserve-3d;
-  margin-bottom: 100px;
-}
-.card:hover .card-body {
-  transform: rotateY(180deg);
-}
-.card-front, .card-back {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  -webkit-backface-visibility: hidden; /* Safari */
-  backface-visibility: hidden;
-}
-.card-front {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font: 2.5em "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color: white;
-  border-radius: .5em;
-}
-.green-gradient {
-  background: linear-gradient(#2F683B,#09150C);
-}
-.blue-gradient {
-  background: linear-gradient(#315394,#0A0F22);
-}
-.red-gradient {
-  background: linear-gradient(#722E2E,#150909);
-}
-.orange-gradient {
-  background: linear-gradient(#9A472C,#261009);
-}
-.card-back {
-  background-color: dodgerblue;
-  color: white;
-  transform: rotateY(180deg);
-}

--- a/styles.css
+++ b/styles.css
@@ -350,7 +350,7 @@ span {
 } */
 
 /* The flip card container - set the width and height to whatever you want. We have added the border property to demonstrate that the flip itself goes out of the box on hover (remove perspective if you don't want the 3D effect */
-.flip-card {
+.card {
     margin-bottom: 50px;
     background-color: transparent;
     width: 1000px;
@@ -360,7 +360,7 @@ span {
 }
 
 /* This container is needed to position the front and back side */
-.flip-card-inner {
+.card-inner {
   position: relative;
   width: 100%;
   height: 100%;
@@ -371,12 +371,12 @@ span {
 }
 
 /* Do an horizontal flip when you move the mouse over the flip box container */
-.flip-card:hover .flip-card-inner {
+.card:hover .card-inner {
   transform: rotateY(180deg);
 }
 
 /* Position the front and back side */
-.flip-card-front, .flip-card-back {
+.card-front, .card-back {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -385,13 +385,13 @@ span {
 }
 
 /* Style the front side (fallback if image is missing) */
-.flip-card-front {
+.card-front {
   background-color: lightblue;
   color: black;
 }
 
 /* Style the back side */
-.flip-card-back {
+.card-back {
   background-color: dodgerblue;
   color: white;
   transform: rotateY(180deg);

--- a/styles.css
+++ b/styles.css
@@ -193,21 +193,22 @@ font-weight: 400;
 }
 
 /********************************* Desktop Dinosaur Cards *********************************/
+.dinosaur-cards {
+  display: flex;
+  flex-direction: column;
+}
 .card {
   width: 550px;
-  min-height: 300px;
-  background-color: transparent;
-  border-radius: 1rem;
+  height: 300px;
+  margin: 10px;
   perspective: 1000px;
 }
 .card-body {
   position: relative;
   width: 100%;
   height: 100%;
-  text-align: center;
   transition: transform 0.8s;
   transform-style: preserve-3d;
-  margin-bottom: 100px;
 }
 .card:hover .card-body {
   transform: rotateY(180deg);
@@ -216,6 +217,7 @@ font-weight: 400;
   position: absolute;
   width: 100%;
   height: 100%;
+  border-radius: 1rem;
   -webkit-backface-visibility: hidden; /* Safari */
   backface-visibility: hidden;
 }
@@ -225,13 +227,26 @@ font-weight: 400;
   align-items: center;
   font: 2.5em "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: white;
-  border-radius: 1em;
+}
+.card:nth-child(4n+1) .card-front {
+  background: linear-gradient(#2F683B,#09150C);
+}
+.card:nth-child(4n+2) .card-front {
+  background: linear-gradient(#315394,#0A0F22);
+}
+.card:nth-child(4n+3) .card-front {
+  background: linear-gradient(#722E2E,#150909);
+}
+.card:nth-child(4n+4) .card-front {
+  background: linear-gradient(#9A472C,#261009);
 }
 .card-back {
-  border-radius: 1em;
   padding: 10px;
   display: inline-flex;
   font: 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
+  background-color: white;
+  border: 1pt solid green;
+  transform: rotateY(180deg);
 }
 .card-back-text {
   width: 300px;
@@ -240,20 +255,16 @@ font-weight: 400;
   padding-bottom: 10px;
   padding-left: 10px;
   padding-right: 10px;
-  background-color: #fff;
-  border: 0px solid #fff;
-  border-radius: .5em 0 0 .5em;
+  border-radius: 1em 0 0 1em;
 }
 .card-back-image-container {
   width: 220px;
   min-height: 300px;
   padding: 10px;
-  background-color: #fff;
-  border: 0px solid #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0 .5em .5em 0;
+  border-radius: 0 1em 1em 0;
 }
 dl {
   display: grid;

--- a/styles.css
+++ b/styles.css
@@ -377,8 +377,13 @@ span {
   backface-visibility: hidden;
 }
 .card-front {
-  background-color: lightblue;
-  color: black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font: 2.5em "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: white;
+  border-radius: .5em;
+}
 }
 .card-back {
   background-color: dodgerblue;


### PR DESCRIPTION
1.  Implement card flip.
    Using Matt's css for flipping cards, I changed some class names to the following.  The card-body div is required to handle the flipping.  The new elements needed were added to Ki's onSearch function that creates the cards.  David's css for the cards.
    ```html
    <div class="card">
      <div class="card-body">
        <div class="card-front"></div>
        <div class="card-back"></div>
      </div>
    </div>
    ```


https://github.com/chingu-voyages/v48-tier1-team-05/assets/51532684/14d82e11-debf-4f12-8f76-39239c136d76


2.  nth-child css is used to create the four background gradients for the card fronts and the four border colors for the card backs borders.

![colored card fronts](https://github.com/chingu-voyages/v48-tier1-team-05/assets/51532684/ed77a17b-5593-49b1-9b59-10f93ea5baed)


**Still needed:**
Solve the problem of the back cards growing too large (Using a min-height doesn't work for having front and back cards in the same space.)


    
