### PR TITLE
add InterVariable font

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,11 @@
+/********************************* General CSS *********************************/
+:root {
+  font-family: Inter, sans-serif;
+  font-feature-settings: 'liga' 1, 'calt' 1; /* fix for Chrome */
+}
+@supports (font-variation-settings: normal) {
+  :root { font-family: InterVariable, sans-serif; }
+}
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
Add the following code from the [Inter Font webpage](https://rsms.me/inter/) so that InterVariable is used instead in browser that support variable fonts.
```css
:root {
  font-family: Inter, sans-serif;
  font-feature-settings: 'liga' 1, 'calt' 1; /* fix for Chrome */
}
@supports (font-variation-settings: normal) {
  :root { font-family: InterVariable, sans-serif; }
}
```