### PR TITLE
fix .hidden problem

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -22,9 +22,6 @@ body {
 section {
   margin-bottom: 100px;
 }
-.hidden {
-  display: none;
-}
 
 /********************************* Top of Page Section *********************************/
 /****************** Header ******************/
@@ -370,15 +367,7 @@ span {
     background: black;
     color: white;
 }
-/* .footer-list {
-  list-style: none;
-  display:flex;
-  align-items: center;
-  justify-content: space-between;
-  box-sizing: border-box;
-  margin: auto 20px;
+
+.hidden {
+  display: none;
 }
-.footer-list li {
-  display: inline-block;
-  color: white;
-} */


### PR DESCRIPTION
Moving the code
```css
.hidden {
  display: none;
}
```
up in styles.css file (line 25), meant that the display property was being overridden in line 150 with
```css
.dinosaur-profiles {
  display: flex;
  flex-direction: column;
  justify-content: flex-start;
  align-items: center;
}
```
Moving the .hidden code to the bottom of the file will resolve this problem.

![Screen Shot 2024-04-11 at 7 29 07 PM](https://github.com/chingu-voyages/v48-tier1-team-05/assets/51532684/81ff0461-5d2b-47bc-8a1b-6fe0a209ece9)
