### PR TITLE
Fix mobile search

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,8 +32,21 @@ async function createData() {
     // create initial chart
     createChart()
 
-    // show all dinosaurs by calling onSearch function
-    onSearch(allDinosaurs)
+    // set initial search eventListener according to screen size
+    // and call onSearch for initial screen size
+    if (window.innerWidth < 500) {
+      const searchInput = document.getElementById("mobileDinoSearch");
+      searchInput.addEventListener("input", function() {
+        onSearch(allDinosaurs, 'mobileDinoSearch');
+      });
+      onSearch(allDinosaurs, 'mobileDinoSearch');
+    } else {
+      const searchInput = document.getElementById("dinoSearch");
+      searchInput.addEventListener("input", function() {
+        onSearch(allDinosaurs, 'dinoSearch');
+      });
+      onSearch(allDinosaurs, 'dinoSearch');
+    }
     return data
 
   } catch(err) {
@@ -62,9 +75,10 @@ function handleClick(event) {
 
 /********************************* Dinosaur Profiles *********************************/
 
-function onSearch(data) {
-    const search = document.getElementById("dinoSearch").value.toLowerCase();
+function onSearch(data, searchElement) {
+    const search = document.getElementById(searchElement).value.toLowerCase();
     const resultContainer = document.getElementById("search-result");
+    const mobileResultContainer = document.getElementById("mobile-search-result")
     const mobileResultContainer = document.getElementById("mobile-search-result")
     
     const filtered = data.filter((dinosaur) => {
@@ -81,10 +95,10 @@ function onSearch(data) {
 
     resultContainer.innerHTML = '';
     mobileResultContainer.innerHTML = '';
+    mobileResultContainer.innerHTML = '';
 
     filtered.forEach((dinosaur) => {
-
-      // create elements needed for desktop cards for desktop cards
+      // create elements needed for desktop cards
       const card = document.createElement('div');
       const cardBody = document.createElement('div');
       const cardFront = document.createElement('div');
@@ -111,10 +125,38 @@ function onSearch(data) {
       mobileCardText.classList.add('child')
       mobileCardText.classList.add('dinosaur-info')
 
-      // create card front
+      //create elements needed for mobile cards
+      const mobileCard = document.createElement('div');
+      const mobileCardBody = document.createElement('div');
+      const mobileCardName = document.createElement('div');
+      const mobileCardText = document.createElement('div');
+      mobileCard.classList.add('card-mobile');
+      mobileCardBody.classList.add('parent');
+      mobileCardName.classList.add('child')
+      mobileCardName.classList.add('header')
+      mobileCardText.classList.add('child')
+      mobileCardText.classList.add('dinosaur-info')
+
+      //create elements needed for mobile cards
+      const mobileCard = document.createElement('div');
+      const mobileCardBody = document.createElement('div');
+      const mobileCardName = document.createElement('div');
+      const mobileCardText = document.createElement('div');
+      mobileCard.classList.add('card-mobile');
+      mobileCardBody.classList.add('parent');
+      mobileCardName.classList.add('child')
+      mobileCardName.classList.add('header')
+      mobileCardText.classList.add('child')
+      mobileCardText.classList.add('dinosaur-info')
+
+      // add dinosaur name to front of desktop card
       cardFrontText.textContent = dinosaur.name;
       cardFront.appendChild(cardFrontText);
 
+      // add dinosaur name to mobile card
+      mobileCardName.textContent = dinosaur.name;
+
+      // create desktop and mobile cards dinosaur info
       // add dinosaur name to mobile card
       mobileCardName.textContent = dinosaur.name;
 
@@ -150,6 +192,7 @@ function onSearch(data) {
         dlElement.appendChild(dtElement);
         dlElement.appendChild(ddElement);
         cardBackText.appendChild(dlElement);
+        mobileCardText.appendChild(dlElement);
       });
       labels.forEach(item => {
         const dlElement = document.createElement('dl');
@@ -196,15 +239,23 @@ function onSearch(data) {
       // append to result containerss
       resultContainer.appendChild(card);
       mobileResultContainer.appendChild(mobileCard);
+      mobileResultContainer.appendChild(mobileCard);
   });
-
 };
-document.addEventListener("DOMContentLoaded", function() {
+// change search eventListener if screen size changes
+window.onresize = function() {
+  if (window.innerWidth < 500) {
+    const searchInput = document.getElementById("mobileDinoSearch");
+    searchInput.addEventListener("input", function() {
+      onSearch(allDinosaurs, 'mobileDinoSearch');
+    });
+  } else {
     const searchInput = document.getElementById("dinoSearch");
     searchInput.addEventListener("input", function() {
-        onSearch(allDinosaurs);
+      onSearch(allDinosaurs, 'dinoSearch');
     });
-});
+  }
+}
 
 /********************************* Dinosaur Maps *********************************/
 

--- a/app.js
+++ b/app.js
@@ -79,7 +79,6 @@ function onSearch(data, searchElement) {
     const search = document.getElementById(searchElement).value.toLowerCase();
     const resultContainer = document.getElementById("search-result");
     const mobileResultContainer = document.getElementById("mobile-search-result")
-    const mobileResultContainer = document.getElementById("mobile-search-result")
     
     const filtered = data.filter((dinosaur) => {
         if (!search) {
@@ -94,7 +93,6 @@ function onSearch(data, searchElement) {
     });
 
     resultContainer.innerHTML = '';
-    mobileResultContainer.innerHTML = '';
     mobileResultContainer.innerHTML = '';
 
     filtered.forEach((dinosaur) => {
@@ -125,38 +123,10 @@ function onSearch(data, searchElement) {
       mobileCardText.classList.add('child')
       mobileCardText.classList.add('dinosaur-info')
 
-      //create elements needed for mobile cards
-      const mobileCard = document.createElement('div');
-      const mobileCardBody = document.createElement('div');
-      const mobileCardName = document.createElement('div');
-      const mobileCardText = document.createElement('div');
-      mobileCard.classList.add('card-mobile');
-      mobileCardBody.classList.add('parent');
-      mobileCardName.classList.add('child')
-      mobileCardName.classList.add('header')
-      mobileCardText.classList.add('child')
-      mobileCardText.classList.add('dinosaur-info')
-
-      //create elements needed for mobile cards
-      const mobileCard = document.createElement('div');
-      const mobileCardBody = document.createElement('div');
-      const mobileCardName = document.createElement('div');
-      const mobileCardText = document.createElement('div');
-      mobileCard.classList.add('card-mobile');
-      mobileCardBody.classList.add('parent');
-      mobileCardName.classList.add('child')
-      mobileCardName.classList.add('header')
-      mobileCardText.classList.add('child')
-      mobileCardText.classList.add('dinosaur-info')
-
       // add dinosaur name to front of desktop card
       cardFrontText.textContent = dinosaur.name;
       cardFront.appendChild(cardFrontText);
 
-      // add dinosaur name to mobile card
-      mobileCardName.textContent = dinosaur.name;
-
-      // create desktop and mobile cards dinosaur info
       // add dinosaur name to mobile card
       mobileCardName.textContent = dinosaur.name;
 
@@ -192,7 +162,6 @@ function onSearch(data, searchElement) {
         dlElement.appendChild(dtElement);
         dlElement.appendChild(ddElement);
         cardBackText.appendChild(dlElement);
-        mobileCardText.appendChild(dlElement);
       });
       labels.forEach(item => {
         const dlElement = document.createElement('dl');
@@ -231,14 +200,8 @@ function onSearch(data, searchElement) {
       mobileCardBody.appendChild(mobileCardText)
       mobileCard.appendChild(mobileCardBody)
 
-      // create mobile card from components
-      mobileCardBody.appendChild(mobileCardName)
-      mobileCardBody.appendChild(mobileCardText)
-      mobileCard.appendChild(mobileCardBody)
-
       // append to result containerss
       resultContainer.appendChild(card);
-      mobileResultContainer.appendChild(mobileCard);
       mobileResultContainer.appendChild(mobileCard);
   });
 };

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
             <form class="search-bar" role="search">
                 <input
                     type="search"
-                    id="dinoSearch"
+                    id="mobileDinoSearch"
                     name="input"
                     placeholder="Type to begin searching ..."
                     aria-label="Search for dinosaurs by name"

--- a/styles.css
+++ b/styles.css
@@ -201,7 +201,6 @@ font-weight: 400;
   display: flex;
   flex-direction: column;
   margin-top: 2em;
-
 }
 .card {
   width: 700px;
@@ -287,22 +286,22 @@ span2 {
 }
 .card:nth-child(4n+1) .card-front,
 .card:nth-child(4n+1) .card-back,
-.card-mobile:nth-child(4n+1) header {
+.card-mobile:nth-child(4n+1) .header {
   background: linear-gradient(#2F683B,#09150C);
 }
 .card:nth-child(4n+2) .card-front,
 .card:nth-child(4n+2) .card-back,
-.card-mobile:nth-child(4n+2) header {
+.card-mobile:nth-child(4n+2) .header {
   background: linear-gradient(#315394,#0A0F22);
 }
 .card:nth-child(4n+3) .card-front,
 .card:nth-child(4n+3) .card-back,
-.card-mobile:nth-child(4n+3) header {
+.card-mobile:nth-child(4n+3) .header {
   background: linear-gradient(#722E2E,#150909);
 }
 .card:nth-child(4n+4) .card-front,
 .card:nth-child(4n+4) .card-back,
-.card-mobile:nth-child(4n+4) header {
+.card-mobile:nth-child(4n+4) .header {
   background: linear-gradient(#9A472C,#261009);
 }
 /****************** End of Results ******************/


### PR DESCRIPTION
The mobile search needed its own eventListener.  Adding the eventListener to both the desktop search and mobile search bars was moved up into the fetch function so they weren't set until the dinosaur data was fetched.

```js
    // set initial search eventListener according to screen size
    // and call onSearch for initial screen size
    if (window.innerWidth < 500) {
      const searchInput = document.getElementById("mobileDinoSearch");
      searchInput.addEventListener("input", function() {
        onSearch(allDinosaurs, 'mobileDinoSearch');
      });
      onSearch(allDinosaurs, 'mobileDinoSearch');
    } else {
      const searchInput = document.getElementById("dinoSearch");
      searchInput.addEventListener("input", function() {
        onSearch(allDinosaurs, 'dinoSearch');
      });
      onSearch(allDinosaurs, 'dinoSearch');
    }
```

I also added a function to change the eventListener from desktop to mobile or vice versa if there was a dynamic screen size change. 

```js
window.onresize = function() {
  if (window.innerWidth < 500) {
    const searchInput = document.getElementById("mobileDinoSearch");
    searchInput.addEventListener("input", function() {
      onSearch(allDinosaurs, 'mobileDinoSearch');
    });
  } else {
    const searchInput = document.getElementById("dinoSearch");
    searchInput.addEventListener("input", function() {
      onSearch(allDinosaurs, 'dinoSearch');
    });
  }
}
```
